### PR TITLE
sepolicy: avoid chrome denials

### DIFF
--- a/file_contexts
+++ b/file_contexts
@@ -226,6 +226,7 @@
 /sys/devices(/soc\.0)?/f9200000\.ssusb/power_supply/usb/current_max                      u:object_r:sysfs_thermal:s0
 /sys/devices(/soc\.0)?/fdb00000\.qcom,kgsl-3d0/kgsl/kgsl-3d0/gpuclk                      u:object_r:sysfs_thermal:s0
 /sys/devices(/soc\.0)?/fdb00000\.qcom,kgsl-3d0/kgsl/kgsl-3d0/max_gpuclk                  u:object_r:sysfs_thermal:s0
+/sys/devices(/soc\.0)?/fdb00000\.qcom,kgsl-3d0/kgsl/kgsl-3d0/reset_count                 u:object_r:sysfs_thermal:s0
 
 # Timekeep
 /sys/devices(/soc\.0)?/00-qcom,pm(8941|8950|8994)_rtc/rtc/rtc0/since_epoch               u:object_r:sysfs_timekeep:s0

--- a/isolated_app.te
+++ b/isolated_app.te
@@ -1,0 +1,1 @@
+allow isolated_app app_data_file:dir getattr;


### PR DESCRIPTION
chrome uses GPU and GPU is handled by thermal...

01-06 15:05:39.297  7460  7460 I CrGpuMain: type=1400 audit(0.0:8): avc: denied { read } for name=reset_count dev=sysfs ino=10880 scontext=u:r:untrusted_app:s0:c512,c768 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1
01-06 15:05:39.297  7460  7460 I CrGpuMain: type=1400 audit(0.0:9): avc: denied { open } for path=/sys/devices/fdb00000.qcom,kgsl-3d0/kgsl/kgsl-3d0/reset_count dev=sysfs ino=10880 scontext=u:r:untrusted_app:s0:c512,c768 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1
01-06 15:05:39.297  7460  7460 I CrGpuMain: type=1400 audit(0.0:10): avc: denied { getattr } for path=/sys/devices/fdb00000.qcom,kgsl-3d0/kgsl/kgsl-3d0/reset_count dev=sysfs ino=10880 scontext=u:r:untrusted_app:s0:c512,c768 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1
01-06 15:05:42.157  7510  7510 I dboxed_process1: type=1400 audit(0.0:11): avc: denied { getattr } for path=/data/data/com.android.chrome dev=mmcblk0p25 ino=32794 scontext=u:r:isolated_app:s0:c512,c768 tcontext=u:object_r:app_data_file:s0:c512,c768 tclass=dir permissive=1
01-06 15:05:56.597  7460  7460 I CrGpuMain: type=1400 audit(0.0:12): avc: denied { read } for name=reset_count dev=sysfs ino=10880 scontext=u:r:untrusted_app:s0:c512,c768 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1
01-06 15:05:56.597  7460  7460 I CrGpuMain: type=1400 audit(0.0:13): avc: denied { open } for path=/sys/devices/fdb00000.qcom,kgsl-3d0/kgsl/kgsl-3d0/reset_count dev=sysfs ino=10880 scontext=u:r:untrusted_app:s0:c512,c768 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1
01-06 15:05:56.597  7460  7460 I CrGpuMain: type=1400 audit(0.0:14): avc: denied { getattr } for path=/sys/devices/fdb00000.qcom,kgsl-3d0/kgsl/kgsl-3d0/reset_count dev=sysfs ino=10880 scontext=u:r:untrusted_app:s0:c512,c768 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>